### PR TITLE
Update seoinspect.php für Redaxo >= 5.10

### DIFF
--- a/lib/seoinspect.php
+++ b/lib/seoinspect.php
@@ -28,7 +28,7 @@ class rex_article_content_base_local extends rex_article_content_base
         $module_id = rex_request('module_id', 'int');
 
         // ---------- alle teile/slices eines artikels auswaehlen
-        $query = 'SELECT ' . rex::getTablePrefix() . 'module.id, ' . rex::getTablePrefix() . 'module.name, ' . rex::getTablePrefix() . 'module.output, ' . rex::getTablePrefix() . 'module.input, ' . rex::getTablePrefix() . 'article_slice.*, ' . rex::getTablePrefix() . 'article.parent_id
+        $query = 'SELECT ' . rex::getTablePrefix() . 'module.id, ' . rex::getTablePrefix() . 'module.key, ' . rex::getTablePrefix() . 'module.name, ' . rex::getTablePrefix() . 'module.output, ' . rex::getTablePrefix() . 'module.input, ' . rex::getTablePrefix() . 'article_slice.*, ' . rex::getTablePrefix() . 'article.parent_id
                         FROM
                             ' . rex::getTablePrefix() . 'article_slice
                         LEFT JOIN ' . rex::getTablePrefix() . 'module ON ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id


### PR DESCRIPTION
Seit Redaxo 5.10 gibt es den module.key. Dieser muss hier auch in der Abfrage eingefügt werden, da es sonst zu Fehlern kommt:
Warning: Field "rex_module.key" does not exist in result! in redaxo/src/core/lib/sql/sql.php on line 766